### PR TITLE
Fix Release Drafter Workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -45,7 +45,7 @@ jobs:
         uses: release-drafter/release-drafter@v7
         with:
           prerelease: ${{ github.event.inputs.release-type != 'release' }}
-          prerelease-identifier: ${{ github.event.inputs.identifier }}
-          include-pre-releases: ${{ github.event.inputs.include-pre-releases }}
+          prerelease-identifier: ${{ github.event.inputs.identifier || 'rc' }}
+          include-pre-releases: ${{ github.event.inputs.include-pre-releases || 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #254

## Summary by Sourcery

Build:
- Set a default prerelease identifier of 'rc' and default enable inclusion of pre-releases when the corresponding workflow dispatch inputs are not provided in the release-drafter GitHub Actions workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation workflow with sensible default values for prerelease configuration, ensuring more consistent and predictable release draft handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->