### PR TITLE
Add README files for core projects and include them in NuGet packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Escendit GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,77 @@
 # Hosting Extensions for .NET Applications
 
-This NuGet package provides streamlined hosting extensions for .NET applications,
-offering simplified configuration and dependency injection setup for building robust,
-distributed applications. It provides opinionated defaults and convenient extension methods
-for integrating popular services like Temporal.io, Orleans, NATS, and ADO.NET.
+[![Build Status](https://github.com/escendit/extensions-hosting/actions/workflows/build.yml/badge.svg)](https://github.com/escendit/extensions-hosting/actions/workflows/build.yml)
+[![NuGet Version](https://img.shields.io/nuget/v/Escendit.Extensions.Hosting.Orleans.svg)](https://www.nuget.org/packages/Escendit.Extensions.Hosting.Orleans)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Key features:
+This repository provides streamlined hosting extensions for .NET applications, offering simplified configuration and dependency injection setup for building robust, distributed applications. It provides opinionated defaults and convenient extension methods for integrating popular services like Temporal.io, Orleans, and OpenTelemetry.
 
-- Simplified Temporal client and worker configuration with hosting integration
-- Orleans clustering, persistence, and streaming setup
-- NATS messaging integration
-- ADO.NET connection management with resilience patterns
-- Secret management integration
-- Built-in dependency injection integration
-- Configuration-driven service setup
-- Production-ready defaults for common use cases
+## Key Features
+
+- **Simplified Temporal.io integration** with hosting-friendly client and worker configuration.
+- **Orleans clustering, persistence, and streaming setup** (including NATS integration).
+- **Service Defaults** including OpenTelemetry (Metrics, Tracing, Logging), Health Checks, and Service Discovery.
+- **UserSecrets management** for local development.
+- **Production-ready defaults** for common use cases.
+
+## Tech Stack
+
+- **Language:** C# 14
+- **Framework:** .NET 10 (ASP.NET Core)
+- **Package Manager:** NuGet with Central Package Management (CPM)
+- **Key Libraries:** Orleans, Temporal.io, OpenTelemetry, Polly (Resilience)
+
+## Project Structure
+
+- `src/Orleans`: Extensions for Microsoft Orleans.
+- `src/Temporalio`: Extensions for Temporal.io SDK.
+- `src/ServiceDefaults`: Shared defaults for OpenTelemetry, Health Checks, and Service Discovery.
+- `src/UserSecrets`: Extensions for working with .NET User Secrets.
+
+## Getting Started
+
+### Requirements
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+
+### Installation
+
+Install the desired package via NuGet:
+
+```bash
+dotnet add package Escendit.Extensions.Hosting.Orleans
+# OR
+dotnet add package Escendit.Extensions.Hosting.Temporalio
+```
+
+### Usage Example (Service Defaults)
+
+In your `Program.cs`:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults(); // Configures OTEL, Health Checks, etc.
+
+var app = builder.Build();
+app.Run();
+```
+
+## Scripts & Commands
+
+- **Build:** `dotnet build`
+- **Test:** `dotnet test` (TODO: Add tests to the project)
+- **Pack:** `dotnet pack`
+
+## Environment Variables
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Endpoint for OpenTelemetry OTLP exporter.
+- `ASPNETCORE_ENVIRONMENT`: Used to determine environment-specific configurations.
+
+## License
+
+Licensed to the Escendit GmbH under one or more agreements.
+The Escendit GmbH licenses this file to you under the Apache License 2.0.
+See the [LICENSE](LICENSE) file for more information.

--- a/src/Orleans/Escendit.Extensions.Hosting.Orleans.csproj
+++ b/src/Orleans/Escendit.Extensions.Hosting.Orleans.csproj
@@ -23,4 +23,10 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt"/>
     <AdditionalFiles Include="PublicAPI.Shipped.txt"/>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>true</Pack>
+      <PackagePath/>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Orleans/README.md
+++ b/src/Orleans/README.md
@@ -1,0 +1,33 @@
+# Orleans Hosting Extensions
+
+[![NuGet Version](https://img.shields.io/nuget/v/Escendit.Extensions.Hosting.Orleans.svg)](https://www.nuget.org/packages/Escendit.Extensions.Hosting.Orleans)
+
+Simplified hosting extensions for [Microsoft Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/).
+
+## Features
+
+- **Silo & Client configuration** with opinionated defaults.
+- **Clustering:** ADO.NET, Redis, and Kubernetes.
+- **Persistence:** ADO.NET.
+- **Reminders:** ADO.NET, Redis.
+- **Streaming:** NATS.
+- **Event Sourcing** defaults.
+- **Telemetry:** Automatic OpenTelemetry integration for Orleans.
+
+## Usage
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddOrleansServerRuntime(); // Configures Silo with defaults
+// OR
+builder.AddOrleansClientRuntime(); // Configures Client with defaults
+
+var app = builder.Build();
+app.Run();
+```
+
+## Configuration
+
+- `Hosting`: Set to `Kubernetes` for Kubernetes hosting.
+- `ClusterOptions`: Binds to `ClusterOptions` for Orleans.

--- a/src/ServiceDefaults/Escendit.Extensions.Hosting.ServiceDefaults.csproj
+++ b/src/ServiceDefaults/Escendit.Extensions.Hosting.ServiceDefaults.csproj
@@ -20,4 +20,10 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt"/>
     <AdditionalFiles Include="PublicAPI.Shipped.txt"/>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>true</Pack>
+      <PackagePath/>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/ServiceDefaults/README.md
+++ b/src/ServiceDefaults/README.md
@@ -1,0 +1,29 @@
+# Service Defaults Hosting Extensions
+
+[![NuGet Version](https://img.shields.io/nuget/v/Escendit.Extensions.Hosting.ServiceDefaults.svg)](https://www.nuget.org/packages/Escendit.Extensions.Hosting.ServiceDefaults)
+
+Opinionated service defaults for .NET applications, inspired by .NET Aspire but tailored for standalone hosting.
+
+## Features
+
+- **OpenTelemetry:** Configures Metrics, Tracing, and Logging with OTLP exporter support.
+- **Health Checks:** Adds a default "self" health check.
+- **Service Discovery:** Integrates Microsoft.Extensions.ServiceDiscovery.
+- **Resilience:** Provides standard resilience handlers for HTTP clients.
+
+## Usage
+
+```csharp
+builder.AddServiceDefaults();
+```
+
+Or for specific scenarios:
+
+```csharp
+builder.AddLowLatencyServiceDefaults();
+builder.AddBackendServiceDefaults();
+```
+
+## Configuration
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: If set, enables OTLP exporter for OpenTelemetry.

--- a/src/Temporalio/Escendit.Extensions.Hosting.Temporalio.csproj
+++ b/src/Temporalio/Escendit.Extensions.Hosting.Temporalio.csproj
@@ -14,4 +14,10 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt"/>
     <AdditionalFiles Include="PublicAPI.Shipped.txt"/>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>true</Pack>
+      <PackagePath/>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Temporalio/README.md
+++ b/src/Temporalio/README.md
@@ -1,0 +1,38 @@
+# Temporalio Hosting Extensions
+
+[![NuGet Version](https://img.shields.io/nuget/v/Escendit.Extensions.Hosting.Temporalio.svg)](https://www.nuget.org/packages/Escendit.Extensions.Hosting.Temporalio)
+
+Simplified hosting extensions for [Temporal.io](https://temporal.io/) .NET SDK.
+
+## Features
+
+- **HostApplicationBuilder Extensions** for Temporal Client and Workers.
+- **Environment-based configuration** for gRPC endpoint, namespace, and task queue.
+- **OpenTelemetry integration** for Temporal Client, Workflows, and Activities.
+
+## Usage
+
+### Add Temporal Client
+
+```csharp
+builder.AddTemporalClient();
+```
+
+### Add Temporal Worker (Hosted Service)
+
+```csharp
+builder.AddTemporalServerRuntime(worker =>
+{
+    worker.AddWorkflow<MyWorkflow>();
+    worker.AddActivity<MyActivity>();
+});
+```
+
+## Configuration
+
+Required environment variables or configuration keys:
+
+- `TEMPORAL_GRPC`: The gRPC endpoint (e.g., `localhost:7233`).
+- `TEMPORAL_NAMESPACE`: The Temporal namespace (e.g., `default`).
+- `TEMPORAL_QUEUE`: The task queue name (required for workers).
+- `TEMPORAL_BUILD_ID`: Optional build ID for worker versioning.

--- a/src/UserSecrets/Escendit.Extensions.Hosting.UserSecrets.csproj
+++ b/src/UserSecrets/Escendit.Extensions.Hosting.UserSecrets.csproj
@@ -6,4 +6,10 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt"/>
     <AdditionalFiles Include="PublicAPI.Shipped.txt"/>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>true</Pack>
+      <PackagePath/>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/UserSecrets/README.md
+++ b/src/UserSecrets/README.md
@@ -1,0 +1,13 @@
+# UserSecrets Hosting Extensions
+
+[![NuGet Version](https://img.shields.io/nuget/v/Escendit.Extensions.Hosting.UserSecrets.svg)](https://www.nuget.org/packages/Escendit.Extensions.Hosting.UserSecrets)
+
+Simplified hosting extensions for working with .NET [User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) during development.
+
+## Usage
+
+```csharp
+builder.AddUserSecrets();
+```
+
+This adds User Secrets to the configuration if the environment is `Development`.


### PR DESCRIPTION
Closes #263

## Summary by Sourcery

Document hosting extensions packages and update root README for NuGet distribution

Documentation:
- Add detailed root README describing features, tech stack, usage, and scripts for hosting extensions.
- Add package-specific READMEs for Orleans, Temporalio, ServiceDefaults, and UserSecrets projects with features, usage, and configuration details.
- Ensure project READMEs are included in their respective NuGet packages.