### PR TITLE
ci: refactor release workflows, split pre-release handling and update release-drafter version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,36 +4,34 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened
       - reopened
       - synchronize
-  workflow_dispatch:
-    inputs:
-      release-type:
-        type: choice
-        default: prerelease
-        description: Release Type
-        options:
-          - release
-          - prerelease
-      identifier:
-        type: string
-        default: rc
-        description: Pre-Release Identifier
-        required: false
-      include-pre-releases:
-        type: boolean
-        default: true
-        description: Include Pre-Releases
+      - labeled
+      - unlabeled
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref_type != 'tag' }}
 
 jobs:
+  update_prerelease_draft:
+    name: "Update Pre-Release Draft"
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Draft Pre-Release"
+        uses: release-drafter/release-drafter@v7.3.1
+        with:
+          prerelease: true
+          prerelease-identifier: rc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   update_release_draft:
     name: "Update Release Draft"
     permissions:
@@ -42,10 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@v7.3.1
         with:
-          prerelease: ${{ github.event.inputs.release-type != 'release' }}
-          prerelease-identifier: ${{ github.event.inputs.identifier || 'rc' }}
-          include-pre-releases: ${{ github.event.inputs.include-pre-releases || 'true' }}
+          prerelease: false
+          prerelease-identifier: ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #287

## Summary by Sourcery

Refactor the release-drafter workflow to separate pre-release and full release handling while tightening its triggers and configuration.

CI:
- Split release-drafter workflow into dedicated pre-release and release draft jobs with explicit prerelease settings and updated triggers.
- Upgrade release-drafter action to version v7.3.1 and simplify workflow inputs by removing manual dispatch configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management workflow configuration to use a newer version of the release-drafter action and simplified pre-release handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->