### PR TITLE
chore(deps): upgrade Escendit.Tools.Branding to v2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,112 +1,112 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="Aspire.Hosting" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Npgsql" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.0" />
-    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Dapper" Version="2.1.66" />
-    <PackageVersion Include="Escendit.Extensions.Workflows" Version="0.1.0-rc.1" />
-    <PackageVersion Include="Escendit.Tools.Branding" Version="1.2.0" />
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.NetAnalyzers" Version="0.6.0" />
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.StyleCopAnalyzers" Version="0.6.0" />
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.xUnitAnalyzers" Version="0.1.0" />
-    <PackageVersion Include="FluentMigrator" Version="7.1.0" />
-    <PackageVersion Include="FluentMigrator.Extensions.Postgres" Version="7.1.0" />
-    <PackageVersion Include="FluentMigrator.Runner" Version="7.1.0" />
-    <PackageVersion Include="FluentMigrator.Runner.Core" Version="7.1.0" />
-    <PackageVersion Include="FluentMigrator.Runner.Postgres" Version="7.1.0" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageVersion Include="GitVersion.MsBuild" Version="6.3.0" />
-    <PackageVersion Include="IdentityModel" Version="7.0.0" />
-    <PackageVersion Include="Immediate.Handlers" Version="2.2.0" />
-    <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.63" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.0.0-1.25277.114" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.13.0" />
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.17.2" />
-    <PackageVersion Include="Microsoft.Kiota.Bundle" Version="1.17.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.Redis" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Core" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.EventSourcing" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.GrainDirectory.AdoNet" Version="10.1.0-alpha.1" />
-    <PackageVersion Include="Microsoft.Orleans.Hosting.Kubernetes" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Reminders.Redis" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Streaming.NATS" Version="10.1.0-alpha.1" />
-    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
-    <PackageVersion Include="Npgsql" Version="10.0.2" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.11.0" />
-    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.Federation" Version="8.1.2" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="8.1.2" />
-    <PackageVersion Include="System.ServiceModel.NetFramingBase" Version="8.1.2" />
-    <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.2" />
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2" />
-    <PackageVersion Include="System.ServiceModel.UnixDomainSocket" Version="8.1.2" />
-    <PackageVersion Include="System.Web.Services.Description" Version="8.1.2" />
-    <PackageVersion Include="Temporalio" Version="1.7.0" />
-    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.14.0" />
-    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.14.0" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
-    <PackageVersion Include="xunit.categories" Version="3.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0"/>
+    <PackageVersion Include="Aspire.Hosting" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Npgsql" Version="9.4.0"/>
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.0"/>
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
+    <PackageVersion Include="Dapper" Version="2.1.66"/>
+    <PackageVersion Include="Escendit.Extensions.Workflows" Version="0.1.0-rc.1"/>
+    <PackageVersion Include="Escendit.Tools.Branding" Version="2.0.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.NetAnalyzers" Version="0.6.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.StyleCopAnalyzers" Version="0.6.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.xUnitAnalyzers" Version="0.1.0"/>
+    <PackageVersion Include="FluentMigrator" Version="7.1.0"/>
+    <PackageVersion Include="FluentMigrator.Extensions.Postgres" Version="7.1.0"/>
+    <PackageVersion Include="FluentMigrator.Runner" Version="7.1.0"/>
+    <PackageVersion Include="FluentMigrator.Runner.Core" Version="7.1.0"/>
+    <PackageVersion Include="FluentMigrator.Runner.Postgres" Version="7.1.0"/>
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0"/>
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.3.0"/>
+    <PackageVersion Include="IdentityModel" Version="7.0.0"/>
+    <PackageVersion Include="Immediate.Handlers" Version="2.2.0"/>
+    <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0"/>
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.63"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.0.0-1.25277.114"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="9.4.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0"/>
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.13.0"/>
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.17.2"/>
+    <PackageVersion Include="Microsoft.Kiota.Bundle" Version="1.17.2"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Clustering.Redis" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Core" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.EventSourcing" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.GrainDirectory.AdoNet" Version="10.1.0-alpha.1"/>
+    <PackageVersion Include="Microsoft.Orleans.Hosting.Kubernetes" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Reminders.Redis" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.1.0"/>
+    <PackageVersion Include="Microsoft.Orleans.Streaming.NATS" Version="10.1.0-alpha.1"/>
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5"/>
+    <PackageVersion Include="Npgsql" Version="10.0.2"/>
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2"/>
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17"/>
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3"/>
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3"/>
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1"/>
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0"/>
+    <PackageVersion Include="SharpZipLib" Version="1.4.2"/>
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.25.0.139117"/>
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0"/>
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.11.0"/>
+    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556"/>
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1"/>
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1"/>
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1"/>
+    <PackageVersion Include="System.ServiceModel.Federation" Version="8.1.2"/>
+    <PackageVersion Include="System.ServiceModel.Http" Version="8.1.2"/>
+    <PackageVersion Include="System.ServiceModel.NetFramingBase" Version="8.1.2"/>
+    <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.2"/>
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2"/>
+    <PackageVersion Include="System.ServiceModel.UnixDomainSocket" Version="8.1.2"/>
+    <PackageVersion Include="System.Web.Services.Description" Version="8.1.2"/>
+    <PackageVersion Include="Temporalio" Version="1.7.0"/>
+    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.14.0"/>
+    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.14.0"/>
+    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.14.0"/>
+    <PackageVersion Include="xunit.v3" Version="3.0.0"/>
+    <PackageVersion Include="xunit.analyzers" Version="1.23.0"/>
+    <PackageVersion Include="xunit.categories" Version="3.0.1"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3"/>
   </ItemGroup>
 </Project>

--- a/src/Orleans/packages.lock.json
+++ b/src/Orleans/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Escendit.Tools.Branding": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "m9mp64bnIxZwebiwarsRl8MQ5W1ZSjoFE8kIV7Q1z28D7O9bM2O9IOSXirSPMayn9ppDmH83WK8ofMbVpNCSbA=="
       },
       "Escendit.Tools.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",

--- a/src/ServiceDefaults/packages.lock.json
+++ b/src/ServiceDefaults/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Escendit.Tools.Branding": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "m9mp64bnIxZwebiwarsRl8MQ5W1ZSjoFE8kIV7Q1z28D7O9bM2O9IOSXirSPMayn9ppDmH83WK8ofMbVpNCSbA=="
       },
       "Escendit.Tools.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",

--- a/src/Temporalio/packages.lock.json
+++ b/src/Temporalio/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Escendit.Tools.Branding": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "m9mp64bnIxZwebiwarsRl8MQ5W1ZSjoFE8kIV7Q1z28D7O9bM2O9IOSXirSPMayn9ppDmH83WK8ofMbVpNCSbA=="
       },
       "Escendit.Tools.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",

--- a/src/UserSecrets/packages.lock.json
+++ b/src/UserSecrets/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Escendit.Tools.Branding": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "m9mp64bnIxZwebiwarsRl8MQ5W1ZSjoFE8kIV7Q1z28D7O9bM2O9IOSXirSPMayn9ppDmH83WK8ofMbVpNCSbA=="
       },
       "Escendit.Tools.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",


### PR DESCRIPTION
Closes #289

## Summary by Sourcery

Upgrade Escendit.Tools.Branding dependency to version 2.0.0 across the solution and refresh associated lock files.

Build:
- Update Escendit.Tools.Branding package version to 2.0.0 in central package management configuration.

Chores:
- Regenerate package lock files for affected projects to reflect updated dependency versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `Escendit.Tools.Branding` dependency to version 2.0.0 across all projects and lock files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->